### PR TITLE
Add test suite for Menus component

### DIFF
--- a/components/menus/main.pwn
+++ b/components/menus/main.pwn
@@ -1,0 +1,6 @@
+// Menus component tests
+
+new Menu:g_iMenu;
+
+#include "components/menus/tests.pwn"
+#include "components/menus/player_tests.pwn"

--- a/components/menus/player_tests.pwn
+++ b/components/menus/player_tests.pwn
@@ -1,0 +1,108 @@
+// Menus component player test suite
+
+PTEST__ ShowAndHideMenuForPlayer(playerid)
+{
+    g_iMenu = CreateMenu("Simple menu test", 0, 200.0, 100.0, 150.0, 150.0);
+    ASSERT_EQ(ShowMenuForPlayer(INVALID_MENU, playerid), 0);
+    ASSERT_EQ(ShowMenuForPlayer(g_iMenu, INVALID_PLAYER_ID), 0);
+    ASSERT_EQ(ShowMenuForPlayer(g_iMenu, playerid), 1);
+    ASK("Can you see the menu on your screen?");
+}
+PTEST_CLOSE__ ShowAndHideMenuForPlayer(playerid)
+{
+    ASSERT_EQ(HideMenuForPlayer(g_iMenu, playerid), 1);
+    ASSERT_EQ(HideMenuForPlayer(g_iMenu, INVALID_PLAYER_ID), 0);
+    DestroyMenu(g_iMenu);
+    ASK("Is the menu hidden?");
+}
+
+PTEST__ GetPlayerMenu(playerid)
+{
+    g_iMenu = CreateMenu("Get menu test", 0, 200.0, 100.0, 150.0, 150.0);
+    ShowMenuForPlayer(g_iMenu, playerid);
+    ASSERT_EQ(GetPlayerMenu(playerid), g_iMenu);
+    HideMenuForPlayer(g_iMenu, playerid);
+    ASSERT_EQ(GetPlayerMenu(playerid), INVALID_MENU);
+    DestroyMenu(g_iMenu);
+}
+
+PTEST__ SetMenuColumnHeader(playerid)
+{
+    g_iMenu = CreateMenu("Column headers test", 2, 200.0, 100.0, 150.0, 150.0);
+    // TODO: Add open.mp assertions for SetMenuColumnHeader
+    SetMenuColumnHeader(g_iMenu, 0, "Col 0");
+    SetMenuColumnHeader(g_iMenu, 1, "Col 1");
+    ShowMenuForPlayer(g_iMenu, playerid);
+    ASK("Can you see the column headers \"Col 0\" and \"Col 1\" in the menu?");
+}
+PTEST_CLOSE__ SetMenuColumnHeader(playerid)
+{
+    HideMenuForPlayer(g_iMenu, playerid);
+    DestroyMenu(g_iMenu);
+}
+
+PTEST__ AddMenuItem(playerid)
+{
+    g_iMenu = CreateMenu("Menu items test", 2, 200.0, 100.0, 150.0, 150.0);
+    SetMenuColumnHeader(g_iMenu, 0, "Col 0");
+    SetMenuColumnHeader(g_iMenu, 1, "Col 1");
+    // FIXME: Return row index from AddMenuItem on success
+    ASSERT_EQ(AddMenuItem(g_iMenu, 0, "Col 0, Row 0"), 0);
+    ASSERT_EQ(AddMenuItem(g_iMenu, 0, "Col 0, Row 1"), 1);
+    ASSERT_EQ(AddMenuItem(g_iMenu, 0, "Col 0, Row 2"), 2);
+    ASSERT_EQ(AddMenuItem(g_iMenu, 1, "Col 1, Row 0"), 3);
+    ASSERT_EQ(AddMenuItem(g_iMenu, 1, "Col 1, Row 1"), 4);
+    ASSERT_EQ(AddMenuItem(g_iMenu, 1, "Col 1, Row 2"), 5);
+    ShowMenuForPlayer(g_iMenu, playerid);
+    ASK("Can you see the menu items in the correct position?");
+}
+PTEST_CLOSE__ AddMenuItem(playerid)
+{
+    HideMenuForPlayer(g_iMenu, playerid);
+    DestroyMenu(g_iMenu);
+}
+
+PTEST__ DisableMenuRow(playerid)
+{
+    g_iMenu = CreateMenu("Disable rows test", 2, 200.0, 100.0, 150.0, 150.0);
+    SetMenuColumnHeader(g_iMenu, 0, "Col 0");
+    SetMenuColumnHeader(g_iMenu, 1, "Col 1");
+    AddMenuItem(g_iMenu, 0, "Col 0, Row 0");
+    AddMenuItem(g_iMenu, 0, "Col 0, Row 1");
+    AddMenuItem(g_iMenu, 0, "Col 0, Row 2");
+    AddMenuItem(g_iMenu, 1, "Col 1, Row 0");
+    AddMenuItem(g_iMenu, 1, "Col 1, Row 1");
+    AddMenuItem(g_iMenu, 1, "Col 1, Row 2");
+    // TODO: Does open.mp return something more useful than "1" or a server crash?
+    DisableMenuRow(g_iMenu, 2); // Col 0, Row 2
+    DisableMenuRow(g_iMenu, 5); // Col 1, Row 2
+    ShowMenuForPlayer(g_iMenu, playerid);
+    ASK("Are the menu items \"Col 0, Row 2\" and \"Col 1, Row 2\" disabled?");
+}
+PTEST_CLOSE__ DisableMenuRow(playerid)
+{
+    HideMenuForPlayer(g_iMenu, playerid);
+    DestroyMenu(g_iMenu);
+}
+
+PTEST__ DisableMenu(playerid)
+{
+    g_iMenu = CreateMenu("Disable menu test", 2, 200.0, 100.0, 150.0, 150.0);
+    SetMenuColumnHeader(g_iMenu, 0, "Col 0");
+    SetMenuColumnHeader(g_iMenu, 1, "Col 1");
+    AddMenuItem(g_iMenu, 0, "Col 0, Row 0");
+    AddMenuItem(g_iMenu, 0, "Col 0, Row 1");
+    AddMenuItem(g_iMenu, 0, "Col 0, Row 2");
+    AddMenuItem(g_iMenu, 1, "Col 1, Row 0");
+    AddMenuItem(g_iMenu, 1, "Col 1, Row 1");
+    AddMenuItem(g_iMenu, 1, "Col 1, Row 2");
+    // TODO: Add open.mp assertions for DisableMenu
+    DisableMenu(g_iMenu);
+    ShowMenuForPlayer(g_iMenu, playerid);
+    ASK("Are all the menu items disabled?");
+}
+PTEST_CLOSE__ DisableMenu(playerid)
+{
+    HideMenuForPlayer(g_iMenu, playerid);
+    DestroyMenu(g_iMenu);
+}

--- a/components/menus/player_tests.pwn
+++ b/components/menus/player_tests.pwn
@@ -10,8 +10,9 @@ PTEST__ ShowAndHideMenuForPlayer(playerid)
 }
 PTEST_CLOSE__ ShowAndHideMenuForPlayer(playerid)
 {
-    ASSERT_EQ(HideMenuForPlayer(g_iMenu, playerid), 1);
+    ASSERT_EQ(HideMenuForPlayer(INVALID_MENU, playerid), 0);
     ASSERT_EQ(HideMenuForPlayer(g_iMenu, INVALID_PLAYER_ID), 0);
+    ASSERT_EQ(HideMenuForPlayer(g_iMenu, playerid), 1);
     DestroyMenu(g_iMenu);
     ASK("Is the menu hidden?");
 }

--- a/components/menus/tests.pwn
+++ b/components/menus/tests.pwn
@@ -1,0 +1,35 @@
+// Menus component test suite
+
+TEST__ CreateMenu()
+{
+    for (new i; i < _:MAX_MENUS; i++)
+        ASSERT_EQ(CreateMenu("Menu", 0, 200.0, 100.0, 150.0, 150.0), Menu:i);
+
+    ASSERT_EQ(CreateMenu("This should fail", 2, 200.0, 100.0, 150.0, 150.0), -1); // FIXME: Returns INVALID_MENU instead
+    // TODO: What happens when you try to create a Menu with 3 columns?
+}
+TEST_CLOSE__ CreateMenu()
+{
+    for (new i; i < _:MAX_MENUS; i++)
+        DestroyMenu(Menu:i);
+}
+
+TEST__ IsValidMenu()
+{
+    ASSERT_EQ(IsValidMenu(INVALID_MENU), 0);
+    g_iMenu = CreateMenu("Menu", 0, 200.0, 100.0, 150.0, 150.0);
+    ASSERT_EQ(IsValidMenu(g_iMenu), 1);
+}
+TEST_CLOSE__ IsValidMenu()
+{
+    DestroyMenu(g_iMenu);
+    ASSERT_EQ(IsValidMenu(g_iMenu), 0);
+}
+
+TEST__ DestroyMenu()
+{
+    ASSERT_EQ(DestroyMenu(INVALID_MENU), false);
+    g_iMenu = CreateMenu("Menu", 0, 200.0, 100.0, 150.0, 150.0);
+    ASSERT_EQ(DestroyMenu(g_iMenu), true);
+    ASSERT_EQ(DestroyMenu(g_iMenu), false);
+}

--- a/test.pwn
+++ b/test.pwn
@@ -17,6 +17,9 @@
 
 #include <YSI_Core\y_testing>
 
+// Test suites
+#include "components/menus/main.pwn"
+
 #define TEST_MESSAGE "HELLO, WORLD!"
 
 forward SendTestMessagePID(playerid);


### PR DESCRIPTION
This PR adds a test suite for the Menus component.

The following natives are tested:
- AddMenuItem
- CreateMenu
- DestroyMenu
- DisableMenu
- DisableMenuRow
- GetPlayerMenu
- HideMenuForPlayer
- IsValidMenu
- SetMenuColumnHeader
- ShowMenuForPlayer