### PR TITLE
Add test suite for Actors component

### DIFF
--- a/components/actors/main.pwn
+++ b/components/actors/main.pwn
@@ -1,0 +1,6 @@
+// Actors component tests
+
+new g_iActor;
+
+#include "components/actors/tests.pwn"
+#include "components/actors/player_tests.pwn"

--- a/components/actors/player_tests.pwn
+++ b/components/actors/player_tests.pwn
@@ -1,0 +1,143 @@
+// Actors component player test suite
+
+PTEST__ A_10_CreateActor(playerid)
+{
+    g_iActor = CreateActor(299, 1000.0, 1005.0, 50.0, 180.0);
+    ASSERT_NE(g_iActor, INVALID_ACTOR_ID);
+    ASK("Can you see the actor in front of you with Skin ID 299 (claude)?");
+}
+PTEST_CLOSE__ A_10_CreateActor(playerid)
+{
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_11_SetActorPos(playerid)
+{
+    g_iActor = CreateActor(0, 1000.0, 1005.0, 50.0, 180.0);
+    ASSERT_EQ(SetActorPos(g_iActor, 1003.0, 1005.0, 50.0), 1);
+    ASK("Can you see the actor on your right? (X: 1003.0, Y: 1005.0, Z: 50.0)");
+}
+PTEST_CLOSE__ A_11_SetActorPos(playerid)
+{
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_12_SetActorVirtualWorld(playerid)
+{
+    g_iActor = CreateActor(0, 1000.0, 1005.0, 50.0, 180.0);
+    ASSERT_EQ(SetActorVirtualWorld(g_iActor, 69), 1);
+    SetPlayerVirtualWorld(playerid, 69);
+    ASK("Can you still see the actor?");
+}
+PTEST_CLOSE__ A_12_SetActorVirtualWorld(playerid)
+{
+    SetPlayerVirtualWorld(playerid, 0);
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_13_SetActorInvulnerable(playerid)
+{
+    g_iActor = CreateActor(0, 1000.0, 1005.0, 50.0, 180.0);
+    ASSERT_EQ(SetActorInvulnerable(g_iActor, false), 1);
+    ASK("Are you able to hit the actor?");
+}
+PTEST_CLOSE__ A_13_SetActorInvulnerable(playerid)
+{
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_14_SetActorFacingAngle(playerid)
+{
+    g_iActor = CreateActor(0, 1000.0, 1005.0, 50.0, 180.0);
+    ASSERT_EQ(SetActorFacingAngle(g_iActor, 0.0), 1);
+    ASK("Is the actor facing north?");
+}
+PTEST_CLOSE__ A_14_SetActorFacingAngle(playerid)
+{
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_15_ApplyActorAnimation(playerid)
+{
+    g_iActor = CreateActor(0, 1000.0, 1005.0, 50.0, 180.0);
+    ASSERT_EQ(ApplyActorAnimation(INVALID_ACTOR_ID, "DEALER", "shop_pay", 4.1, true, 0, 0, 0, 0), 0);
+    ASSERT_EQ(ApplyActorAnimation(g_iActor, "DEALER", "shop_pay", 4.1, true, 0, 0, 0, 0), 1);
+    ASK("Is the actor acting like he's paying in a shop?");
+}
+PTEST_CLOSE__ A_15_ApplyActorAnimation(playerid)
+{
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_16_ClearActorAnimations(playerid)
+{
+    g_iActor = CreateActor(0, 1000.0, 1005.0, 50.0, 180.0);
+    ApplyActorAnimation(g_iActor, "DEALER", "shop_pay", 4.1, true, 0, 0, 0, 0);
+    ASSERT_EQ(ClearActorAnimations(INVALID_ACTOR_ID), 0);
+    ASSERT_EQ(ClearActorAnimations(g_iActor), 1);
+    ASK("Has the actor stopped animating?");
+}
+PTEST_CLOSE__ A_16_ClearActorAnimations(playerid)
+{
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_17_GetPlayerTargetActor(playerid)
+{
+    g_iActor = CreateActor(0, 1000.0, 1005.0, 50.0, 180.0);
+    ASSERT_EQ(GetPlayerTargetActor(playerid), INVALID_ACTOR_ID);
+    GivePlayerWeapon(playerid, 24, 3);
+    ASK("Aim at the actor and press ~k~~CONVERSATION_YES~ when ready.");
+}
+PTEST_CLOSE__ A_17_GetPlayerTargetActor(playerid)
+{
+    ASSERT_EQ(GetPlayerTargetActor(playerid), g_iActor);
+    ResetPlayerWeapons(playerid);
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_18_GetPlayerCameraTA(playerid)
+{
+    EnablePlayerCameraTarget(playerid, true);
+    g_iActor = CreateActor(0, 1000.0, 1005.0, 50.0, 180.0);
+    
+    ASK("Look at the actor and press ~k~~CONVERSATION_YES~ when ready.");
+}
+PTEST_CLOSE__ A_18_GetPlayerCameraTA(playerid)
+{
+    ASSERT_EQ(GetPlayerCameraTargetActor(playerid), g_iActor);
+    EnablePlayerCameraTarget(playerid, false);
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_19_GetPlayerCameraTA(playerid)
+{
+    EnablePlayerCameraTarget(playerid, true);
+    g_iActor = CreateActor(0, 1000.0, 1005.0, 50.0, 180.0);
+    
+    ASK("Look away from the actor and press ~k~~CONVERSATION_YES~ when ready.");
+}
+PTEST_CLOSE__ A_19_GetPlayerCameraTA(playerid)
+{
+    ASSERT_EQ(GetPlayerCameraTargetActor(playerid), INVALID_ACTOR_ID);
+    EnablePlayerCameraTarget(playerid, false);
+    DestroyActor(g_iActor);
+}
+
+PTEST__ A_20_IsActorStreamedIn(playerid)
+{
+    // TODO: Improve test - it takes a while to stream in the actor
+    g_iActor = CreateActor(0, 0.0, 0.0, 3.0, 0.0);
+    ASSERT_EQ(IsActorStreamedIn(g_iActor, playerid), 0);
+    ASSERT_EQ(IsActorStreamedIn(g_iActor, INVALID_PLAYER_ID), 0);
+    ASSERT_EQ(IsActorStreamedIn(INVALID_ACTOR_ID, playerid), 0);
+
+    SetPlayerPos(playerid, 3.0, 3.0, 3.0);
+    ASK("Did you spawn at 3.0 3.0 3.0?");
+}
+PTEST_CLOSE__ A_20_IsActorStreamedIn(playerid)
+{
+    ASSERT_EQ(IsActorStreamedIn(g_iActor, playerid), 1);
+    SpawnPlayer(playerid);
+    DestroyActor(g_iActor);
+}

--- a/components/actors/tests.pwn
+++ b/components/actors/tests.pwn
@@ -1,0 +1,147 @@
+// Actors component test suite
+
+TEST__ A_01_CreateActor()
+{
+    for (new i; i < MAX_ACTORS; i++)
+        ASSERT_EQ(CreateActor(0, 0.0, 0.0, 0.0, 0.0), i);
+
+    ASSERT_EQ(CreateActor(0, 1.0, 2.0, 3.0, 20.0), INVALID_ACTOR_ID);
+}
+TEST_CLOSE__ A_01_CreateActor()
+{
+    for (new i; i < MAX_ACTORS; i++)
+        DestroyActor(i);
+}
+
+TEST__ A_02_GetActorPoolSize()
+{
+    ASSERT_EQ(GetActorPoolSize(), 0);
+
+    for (new i; i < 5; i++)
+        CreateActor(0, 0.0, 0.0, 0.0, 0.0);
+
+    ASSERT_EQ(GetActorPoolSize(), 4);
+    DestroyActor(2);
+    ASSERT_EQ(GetActorPoolSize(), 4);
+}
+TEST_CLOSE__ A_02_GetActorPoolSize()
+{
+    for (new i; i < 5; i++)
+        DestroyActor(i);
+    ASSERT_EQ(GetActorPoolSize(), 0);
+}
+
+TEST__ A_03_GetAndSetActorVW()
+{
+    g_iActor = CreateActor(0, 0.0, 0.0, 0.0, 0.0);
+    ASSERT_EQ(GetActorVirtualWorld(INVALID_ACTOR_ID), 0);
+    ASSERT_EQ(SetActorVirtualWorld(INVALID_ACTOR_ID, 69), 0);
+
+    ASSERT_EQ(GetActorVirtualWorld(g_iActor), 0);
+    ASSERT_EQ(SetActorVirtualWorld(g_iActor, 69), 1);
+    ASSERT_EQ(GetActorVirtualWorld(g_iActor), 69);
+    ASSERT_EQ(SetActorVirtualWorld(g_iActor, -69), 1);
+    ASSERT_EQ(GetActorVirtualWorld(g_iActor), -69);
+}
+TEST_CLOSE__ A_03_GetAndSetActorVW()
+{
+    DestroyActor(g_iActor);
+}
+
+TEST__ A_04_GetAndSetActorPos()
+{
+    g_iActor = CreateActor(0, 1.0, 2.0, 3.0, 0.0);
+    new Float:x, Float:y, Float:z;
+
+    ASSERT_EQ(GetActorPos(INVALID_ACTOR_ID, x, y, z), 0);
+    ASSERT_EQ(SetActorPos(INVALID_ACTOR_ID, 1.0, 2.0, 3.0), 0);
+
+    ASSERT_EQ(GetActorPos(g_iActor, x, y, z), 1);
+    ASSERT_EQ(x, 1.0);
+    ASSERT_EQ(y, 2.0);
+    ASSERT_EQ(z, 3.0);
+    ASSERT_EQ(SetActorPos(g_iActor, 10.0, 20.0, 3.0), 1);
+    ASSERT_EQ(GetActorPos(g_iActor, x, y, z), 1);
+    ASSERT_EQ(x, 10.0);
+    ASSERT_EQ(y, 20.0);
+    ASSERT_EQ(z, 3.0);
+}
+TEST_CLOSE__ A_04_GetAndSetActorPos()
+{
+    DestroyActor(g_iActor);
+}
+
+TEST__ A_05_IsAndSetActorInv()
+{
+    g_iActor = CreateActor(0, 0.0, 0.0, 0.0, 0.0);
+    ASSERT_EQ(IsActorInvulnerable(INVALID_ACTOR_ID), 0);
+    ASSERT_EQ(SetActorInvulnerable(INVALID_ACTOR_ID, true), 0);
+
+    ASSERT_EQ(IsActorInvulnerable(g_iActor), 1);
+    ASSERT_EQ(SetActorInvulnerable(g_iActor, false), 1);
+    ASSERT_EQ(IsActorInvulnerable(g_iActor), 0);
+}
+TEST_CLOSE__ A_05_IsAndSetActorInv()
+{
+    DestroyActor(g_iActor);
+}
+
+TEST__ A_06_GetAndSetActorHealth()
+{
+    g_iActor = CreateActor(0, 0.0, 0.0, 0.0, 0.0);
+    new Float:health;
+
+    ASSERT_EQ(GetActorHealth(INVALID_ACTOR_ID, health), 0);
+    ASSERT_EQ(SetActorHealth(INVALID_ACTOR_ID, 69.0), 0);
+
+    ASSERT_EQ(GetActorHealth(g_iActor, health), 1);
+    ASSERT_EQ(health, 100.0);
+    ASSERT_EQ(SetActorHealth(g_iActor, 69.0), 1);
+    ASSERT_EQ(GetActorHealth(g_iActor, health), 1);
+    ASSERT_EQ(health, 69.0);
+}
+TEST_CLOSE__ A_06_GetAndSetActorHealth()
+{
+    DestroyActor(g_iActor);
+}
+
+TEST__ A_07_GetAndSetActorFacingA()
+{
+    g_iActor = CreateActor(0, 0.0, 0.0, 0.0, 30.0);
+    new Float:angle;
+
+    ASSERT_EQ(GetActorFacingAngle(INVALID_ACTOR_ID, angle), 0);
+    ASSERT_EQ(SetActorFacingAngle(INVALID_ACTOR_ID, 69.0), 0);
+
+    ASSERT_EQ(GetActorFacingAngle(g_iActor, angle), 1);
+    ASSERT_EQ(angle, 30.0);
+    ASSERT_EQ(SetActorFacingAngle(g_iActor, 69.0), 1);
+    ASSERT_EQ(GetActorFacingAngle(g_iActor, angle), 1);
+    ASSERT_EQ(angle, 69.0);
+}
+TEST_CLOSE__ A_07_GetAndSetActorFacingA()
+{
+    DestroyActor(g_iActor);
+}
+
+TEST__ A_08_IsValidActor()
+{
+    g_iActor = CreateActor(0, 0.0, 0.0, 0.0, 0.0);
+
+    ASSERT_EQ(IsValidActor(INVALID_ACTOR_ID), 0);
+    ASSERT_EQ(IsValidActor(g_iActor), 1);
+}
+TEST_CLOSE__ A_08_IsValidActor()
+{
+    DestroyActor(g_iActor);
+    ASSERT_EQ(IsValidActor(g_iActor), 0);
+}
+
+TEST__ A_09_DestroyActor()
+{
+    g_iActor = CreateActor(0, 0.0, 0.0, 0.0, 0.0);
+
+    ASSERT_EQ(DestroyActor(INVALID_ACTOR_ID), 0);
+    ASSERT_EQ(DestroyActor(g_iActor), 1);
+    ASSERT_EQ(DestroyActor(g_iActor), 0);
+}

--- a/test.pwn
+++ b/test.pwn
@@ -3,7 +3,7 @@
 // Run tests.
 #define RUN_TESTS
 // Uncomment (and edit) to run a single test case
-//#define JUST_TEST TestName
+// #define JUST_TEST TestName
 
 // Minimal YSI.
 #define YSI_NO_DIALOG_ASK
@@ -19,6 +19,7 @@
 
 // Test suites
 #include "components/menus/main.pwn"
+#include "components/actors/main.pwn"
 #include "components/players/main.pwn"
 
 main()


### PR DESCRIPTION
This PR adds a test suite for the Actors component.

The following natives are tested:
- IsActorStreamedIn
- GetPlayerCameraTargetActor
- GetPlayerTargetActor
- ClearActorAnimations
- ApplyActorAnimation
- GetActorPoolSize
- IsValidActor
- DestroyActor
- GetActorFacingAngle
- SetActorFacingAngle
- GetActorHealth
- SetActorHealth
- IsActorInvulnerable
- SetActorInvulnerable
- GetActorPos
- SetActorPos
- GetActorVirtualWorld
- SetActorVirtualWorld
- CreateActor