### PR TITLE
Add test suite for GangZones component

### DIFF
--- a/components/gangzones/main.pwn
+++ b/components/gangzones/main.pwn
@@ -1,0 +1,8 @@
+// GangZones component tests
+
+new g_iGangZone;
+
+#include "components/gangzones/tests.pwn"
+#include "components/gangzones/player_tests.pwn"
+
+// vim: se ft=cpp:

--- a/components/gangzones/player_tests.pwn
+++ b/components/gangzones/player_tests.pwn
@@ -1,0 +1,109 @@
+// GangZones component player test suite
+
+PTEST__ GZ_03_GangZoneShowForPlayer(playerid)
+{
+    g_iGangZone = GangZoneCreate(955.0, 955.0, 1045.0, 1045.0);
+    ASSERT_EQ(GangZoneShowForPlayer(playerid, INVALID_GANG_ZONE, -1), 0);
+    ASSERT_EQ(GangZoneShowForPlayer(INVALID_PLAYER_ID, g_iGangZone, -1), 0);
+    ASSERT_EQ(GangZoneShowForPlayer(playerid, g_iGangZone, -1), 1);
+    ASK("Can you see the white gangzone near 1000.0 1000.0 50.0?");
+}
+PTEST_CLOSE__ GZ_03_GangZoneShowForPlayer(playerid)
+{
+    GangZoneDestroy(g_iGangZone);
+}
+
+PTEST__ GZ_04_GangZoneShowForAll(playerid)
+{
+    g_iGangZone = GangZoneCreate(955.0, 955.0, 1045.0, 1045.0);
+    ASSERT_EQ(GangZoneShowForAll(INVALID_GANG_ZONE, -1), 0);
+    ASSERT_EQ(GangZoneShowForAll(g_iGangZone, -1), 1);
+    ASK("Can you see the white gangzone near 1000.0 1000.0 50.0?");
+}
+PTEST_CLOSE__ GZ_04_GangZoneShowForAll(playerid)
+{
+    GangZoneDestroy(g_iGangZone);
+}
+
+PTEST__ GZ_05_GangZoneHideForPlayer(playerid)
+{
+    g_iGangZone = GangZoneCreate(955.0, 955.0, 1045.0, 1045.0);
+    ASSERT_EQ(GangZoneHideForPlayer(playerid, INVALID_GANG_ZONE), 0);
+    ASSERT_EQ(GangZoneHideForPlayer(INVALID_PLAYER_ID, g_iGangZone), 0);
+    GangZoneShowForPlayer(playerid, g_iGangZone, -1);
+    ASSERT_EQ(GangZoneHideForPlayer(playerid, g_iGangZone), 1);
+    ASK("Has the zone near 1000.0 1000.0 50.0 disappeared?");
+}
+PTEST_CLOSE__ GZ_05_GangZoneHideForPlayer(playerid)
+{
+    GangZoneDestroy(g_iGangZone);
+}
+
+PTEST__ GZ_06_GangZoneHideForAll(playerid)
+{
+    g_iGangZone = GangZoneCreate(955.0, 955.0, 1045.0, 1045.0);
+    ASSERT_EQ(GangZoneHideForAll(INVALID_GANG_ZONE), 0);
+    GangZoneShowForAll(g_iGangZone, -1);
+    ASSERT_EQ(GangZoneHideForAll(g_iGangZone), 1);
+    ASK("Has the zone near 1000.0 1000.0 50.0 disappeared?");
+}
+PTEST_CLOSE__ GZ_06_GangZoneHideForAll(playerid)
+{
+    GangZoneDestroy(g_iGangZone);
+}
+
+PTEST__ GZ_07_GangZoneFlashForPlayer(playerid)
+{
+    g_iGangZone = GangZoneCreate(955.0, 955.0, 1045.0, 1045.0);
+    ASSERT_EQ(GangZoneFlashForPlayer(playerid, INVALID_GANG_ZONE, 255), 0);
+    ASSERT_EQ(GangZoneFlashForPlayer(INVALID_PLAYER_ID, g_iGangZone, 255), 0);
+    GangZoneShowForPlayer(playerid, g_iGangZone, -1);
+    ASSERT_EQ(GangZoneFlashForPlayer(playerid, g_iGangZone, 255), 1);
+    ASK("Is the white gangzone near 1000.0 1000.0 50.0 flashing black?");
+}
+PTEST_CLOSE__ GZ_07_GangZoneFlashForPlayer(playerid)
+{
+    GangZoneDestroy(g_iGangZone);
+}
+
+PTEST__ GZ_08_GangZoneFlashForAll(playerid)
+{
+    g_iGangZone = GangZoneCreate(955.0, 955.0, 1045.0, 1045.0);
+    ASSERT_EQ(GangZoneFlashForAll(INVALID_GANG_ZONE, 255), 0);
+    GangZoneShowForAll(g_iGangZone, -1);
+    ASSERT_EQ(GangZoneFlashForAll(g_iGangZone, 255), 1);
+    ASK("Is the white gangzone near 1000.0 1000.0 50.0 flashing black?");
+}
+PTEST_CLOSE__ GZ_08_GangZoneFlashForAll(playerid)
+{
+    GangZoneDestroy(g_iGangZone);
+}
+
+PTEST__ GZ_09_GangZoneStopFlashForPlayer(playerid)
+{
+    g_iGangZone = GangZoneCreate(955.0, 955.0, 1045.0, 1045.0);
+    ASSERT_EQ(GangZoneStopFlashForPlayer(playerid, INVALID_GANG_ZONE), 0);
+    ASSERT_EQ(GangZoneStopFlashForPlayer(INVALID_PLAYER_ID, g_iGangZone), 0);
+    GangZoneShowForPlayer(playerid, g_iGangZone, -1);
+    GangZoneFlashForPlayer(playerid, g_iGangZone, 255);
+    ASSERT_EQ(GangZoneStopFlashForPlayer(playerid, g_iGangZone), 1);
+    ASK("Has the gangzone near 1000.0 1000.0 50.0 stopped flashing?");
+}
+PTEST_CLOSE__ GZ_09_GangZoneStopFlashForPlayer(playerid)
+{
+    GangZoneDestroy(g_iGangZone);
+}
+
+PTEST__ GZ_10_GangZoneStopFlashForAll(playerid)
+{
+    g_iGangZone = GangZoneCreate(955.0, 955.0, 1045.0, 1045.0);
+    ASSERT_EQ(GangZoneStopFlashForAll(INVALID_GANG_ZONE), 0);
+    GangZoneShowForAll(g_iGangZone, -1);
+    GangZoneFlashForAll(g_iGangZone, 255);
+    ASSERT_EQ(GangZoneStopFlashForAll(g_iGangZone), 1);
+    ASK("Has the gangzone near 1000.0 1000.0 50.0 stopped flashing?");
+}
+PTEST_CLOSE__ GZ_10_GangZoneStopFlashForAll(playerid)
+{
+    GangZoneDestroy(g_iGangZone);
+}

--- a/components/gangzones/tests.pwn
+++ b/components/gangzones/tests.pwn
@@ -1,0 +1,24 @@
+// GangZones component test suite
+
+TEST__ GZ_01_GangZoneCreate()
+{
+    for (new i; i < MAX_GANG_ZONES; i++)
+        ASSERT_EQ(GangZoneCreate(0.0, 0.0, 0.0, 0.0), i);
+
+    ASSERT_EQ(GangZoneCreate(0.0, 0.0, 0.0, 0.0), -1);
+}
+TEST_CLOSE__ GZ_01_GangZoneCreate()
+{
+    for (new i; i < MAX_GANG_ZONES; i++)
+        GangZoneDestroy(i);
+}
+
+TEST__ GZ_02_GangZoneDestroy()
+{
+    new gangzone = GangZoneCreate(0.0, 0.0, 0.0, 0.0);
+    ASSERT_EQ(GangZoneDestroy(gangzone), 1);
+    ASSERT_EQ(GangZoneDestroy(gangzone), 0);
+    ASSERT_EQ(GangZoneDestroy(INVALID_GANG_ZONE), 0);
+}
+
+// vim: se ft=cpp:

--- a/test.pwn
+++ b/test.pwn
@@ -27,6 +27,7 @@
 #include "components/actors/main.pwn"
 #include "components/players/main.pwn"
 #include "components/consolevars/main.pwn"
+#include "components/gangzones/main.pwn"
 
 main()
 {

--- a/test.pwn
+++ b/test.pwn
@@ -3,6 +3,8 @@
 	#include <fixes>
 #endif
 
+#pragma warning disable 200
+
 // Run tests.
 #define RUN_TESTS
 // Uncomment (and edit) to run a single test case


### PR DESCRIPTION
This PR adds a test suite for the GangZones component.

The following natives are tested:
- GangZoneFlashForAll
- GangZoneFlashForPlayer
- GangZoneHideForAll
- GangZoneHideForPlayer
- GangZoneShowForAll
- GangZoneStopFlashForAll
- GangZoneStopFlashForPlayer
- GangZoneShowForPlayer
- GangZoneDestroy
- GangZoneCreate
